### PR TITLE
Feature/scan table

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
     storage/dictionary_segment.hpp
     storage/fitted_attribute_vector.cpp
     storage/fitted_attribute_vector.hpp
+    storage/reference_segment.cpp
     storage/reference_segment.hpp
     storage/storage_manager.cpp
     storage/storage_manager.hpp

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
     operators/get_table.cpp
     operators/print.cpp
     operators/print.hpp
+    operators/table_scan.cpp
     operators/table_scan.hpp
     operators/table_wrapper.cpp
     operators/table_wrapper.hpp

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -14,11 +14,16 @@ AbstractOperator::AbstractOperator(const std::shared_ptr<const AbstractOperator>
                                    const std::shared_ptr<const AbstractOperator> right)
     : _input_left(left), _input_right(right) {}
 
-void AbstractOperator::execute() { _output = _on_execute(); }
+void AbstractOperator::execute() {
+  Assert(_input_left == nullptr || _input_left->_output != nullptr,
+         "You need to execute the left input operator before executing this one.");
+  Assert(_input_right == nullptr || _input_right->_output != nullptr,
+         "You need to execute the right input operator before executing this one.");
+  _output = _on_execute();
+}
 
 std::shared_ptr<const Table> AbstractOperator::get_output() const {
-  // TODO(anyone): You should place some meaningful checks here
-
+  Assert(_output != nullptr, "You need to execute this operator before requesting its output.");
   return _output;
 }
 

--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -14,7 +14,7 @@ class Table;
 // All operators have up to two input tables and one output table.
 // Their lifecycle has three phases:
 // 1. The operator is constructed. Previous operators are not guaranteed to have already executed, so operators must not
-// call get_output in their execute method
+// call get_output in their constructor.
 // 2. The execute method is called from the outside (usually by the scheduler). This is where the heavy lifting is done.
 // By now, the input operators have already executed.
 // 3. The consumer (usually another operator) calls get_output. This should be very cheap. It is only guaranteed to

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -17,10 +17,6 @@ TableScan::TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID 
                      const AllTypeVariant search_value)
     : AbstractOperator(in), _column_id(column_id), _scan_type(scan_type), _search_value(search_value) {}
 
-TableScan::~TableScan() {
-  // TODO
-}
-
 ColumnID TableScan::column_id() const { return _column_id; }
 
 ScanType TableScan::scan_type() const { return _scan_type; }

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -128,7 +128,7 @@ std::shared_ptr<const Table> TableScan::TableScanImpl<T>::execute() {
   } else {
     auto& last_chunk = result_table->get_chunk(ChunkID(result_table->chunk_count() - 1));
     if (last_chunk.column_count() == 0) {
-      Assert(result_table->chunk_count() == 1, "Only when the table has just one chunk it can be empty.");
+      DebugAssert(result_table->chunk_count() == 1, "Only when the table has just one chunk it can be empty.");
       for (auto column_idx = ColumnID(0); column_idx < result_table->column_count(); ++column_idx) {
         last_chunk.add_segment(
             make_shared_by_data_type<BaseSegment, ValueSegment>(result_table->column_type(column_idx)));
@@ -159,7 +159,7 @@ void TableScan::TableScanImpl<T>::_scan_segment(const ChunkID current_chunk_id, 
   for (size_t i = 0; i < segment->size(); ++i) {
     if (_matches_search_value(segment->get(i))) {
       auto row_id = RowID();
-      row_id.chunk_offset = i;
+      row_id.chunk_offset = ChunkOffset(i);
       row_id.chunk_id = current_chunk_id;
       pos_list->emplace_back(std::move(row_id));
     }
@@ -197,7 +197,7 @@ void TableScan::TableScanImpl<T>::_scan_segment(std::shared_ptr<PosList> pos_lis
       auto row_id = RowID();
       row_id.chunk_offset = chunk_offset;
       row_id.chunk_id = chunk_id;
-      pos_list->emplace_back(row_id);
+      pos_list->emplace_back(std::move(row_id));
     }
   }
 }
@@ -226,7 +226,6 @@ bool TableScan::TableScanImpl<T>::_matches_search_value(const T& value) const {
     }
     default: { Fail("Unknown scan type operator"); }
   }
-  return false;  // TODO: Does this really need to be here?
 }
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -1,0 +1,92 @@
+#include "table_scan.hpp"
+#include "resolve_type.hpp"
+#include "../storage/table.hpp"
+#include "../storage/chunk.hpp"
+#include "../storage/value_segment.hpp"
+#include "../storage/dictionary_segment.hpp"
+#include "../storage/reference_segment.hpp"
+
+namespace opossum {
+
+TableScan::TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID column_id, const ScanType scan_type,
+                     const AllTypeVariant search_value)
+    : AbstractOperator(in) {
+  const auto table = in->get_output();
+  _table_scan_impl = make_unique_by_data_type<BaseTableScanImpl, TableScanImpl>(table->column_type(column_id));
+}
+
+TableScan::TableScanImpl::TableScanImpl(
+  const std::shared_ptr<const Table> table, ColumnID column_id, const ScanType scan_type,
+  const AllTypeVariant search_value) : _table(table), _column_id(column_id), _scan_type(scan_type),
+                _search_value(type_cast<T>(search_value)) {
+
+};
+
+const std::shared_ptr<Table> TableScan::TableScanImpl::execute() const {
+  const auto result_table = std::make_shared<Table>();
+  Chunk result_chunk;
+
+  for (auto chunk_index = ChunkID(0); chunk_index < _table->chunk_count(); ++chunk_index) {
+    const Chunk& chunk = _table->get_chunk(chunk_index); // TODO: auto
+
+    const auto& segment = chunk.get_segment(_column_id);
+
+    const auto& value_segment = std::dynamic_pointer_cast<ValueSegment<T>>(segment);
+    if (value_segment != nullptr) {
+      _scan_segment(result_table, value_segment);
+      continue;
+    }
+    /*
+    const auto& dict_segment = std::dynamic_pointer_cast<DictionarySegment<T>>(segment);
+    if (dict_segment != nullptr) {
+      // TODO: Smartly iterate the dictionary.
+
+      continue;
+    }
+    const auto& reference_segment = std::dynamic_pointer_cast<ReferenceSegment<T>>(segment);
+    if (reference_segment != nullptr) {
+
+      continue;
+    }
+    */
+
+    Fail("Type mismatch: Cannot cast table segments to type of search_value.");
+  }
+}
+
+void TableScan::TableScanImpl::_scan_segment(std::shared_ptr<opossum::Table> table,
+                                             std::shared_ptr<ValueSegment<T>> segment) const {
+  for (const auto& value : segment->values()) {
+    if (_matches_search_value(value)) {
+
+    }
+  }
+}
+
+bool TableScan::TableScanImpl::_matches_search_value(const T &value) const {
+  switch (_scan_type) {
+    case ScanType::OpEquals: {
+      return value == _search_value;
+    }
+    case ScanType::OpNotEquals: {
+      return value != _search_value;
+    }
+    case ScanType::OpGreaterThan: {
+      return value > _search_value;
+    }
+    case ScanType::OpGreaterThanEquals: {
+      return value >= _search_value;
+    }
+    case ScanType::OpLessThan: {
+      return value < _search_value;
+    }
+    case ScanType::OpLessThanEquals: {
+      return value <= _search_value;
+    }
+    default: {
+      Fail("Unknown scan type operator");
+    }
+  }
+}
+
+}  // namespace opossum

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -41,11 +41,17 @@ TableScan::TableScanImpl<T>::TableScanImpl(const std::shared_ptr<const Table> ta
 
 template <typename T>
 std::shared_ptr<const Table> TableScan::TableScanImpl<T>::execute() {
+  // First create an empty result_table with the column definitions copied from the input _table.
+  // This does not add segments to the table.
   const auto result_table = std::make_shared<Table>();
   for (auto column_idx = ColumnID(0); column_idx < _table->column_count(); ++column_idx) {
     result_table->add_column_definition(_table->column_name(column_idx), _table->column_type(column_idx));
   }
-  const auto result_pos_list = std::make_shared<PosList>();
+
+  auto result_pos_list = std::make_shared<PosList>();
+
+  Chunk result_chunk;
+  std::shared_ptr<const Table> last_referenced_table = nullptr;
 
   for (auto chunk_index = ChunkID(0); chunk_index < _table->chunk_count(); ++chunk_index) {
     const auto& chunk = _table->get_chunk(chunk_index);
@@ -53,53 +59,147 @@ std::shared_ptr<const Table> TableScan::TableScanImpl<T>::execute() {
 
     const auto& value_segment = std::dynamic_pointer_cast<ValueSegment<T>>(segment_to_scan);
     if (value_segment != nullptr) {
-      const auto matches = _scan_segment(value_segment);
-      for (const auto matchedChunkOffset : matches) {
-        auto row_id = RowID();
-        row_id.chunk_offset = matchedChunkOffset;
-        row_id.chunk_id = chunk_index;
-        result_pos_list->emplace_back(std::move(row_id));
+      if (last_referenced_table != nullptr && last_referenced_table != _table && !result_pos_list->empty()) {
+        // The last ReferenceSegment we added pointed to a table different from the table this segment is part of. Thus,
+        // we need to add the last result_chunk to the result_table and create a new chunk with a new ReferenceSegment.
+
+        for (auto column_idx = ColumnID(0); column_idx < last_referenced_table->column_count(); ++column_idx) {
+          const auto segment = std::make_shared<ReferenceSegment>(last_referenced_table, column_idx, result_pos_list);
+          result_chunk.add_segment(segment);
+        }
+        result_table->emplace_chunk(std::move(result_chunk));
+        result_chunk = Chunk();
+        result_pos_list = std::make_shared<PosList>();
       }
+      last_referenced_table = _table;
+      _scan_segment(chunk_index, result_pos_list, value_segment);
       continue;
     }
-    /*
-    const auto& dict_segment = std::dynamic_pointer_cast<DictionarySegment<T>>(segment);
+
+    const auto& dict_segment = std::dynamic_pointer_cast<DictionarySegment<T>>(segment_to_scan);
     if (dict_segment != nullptr) {
-      // TODO: Smartly iterate the dictionary.
+      if (last_referenced_table != nullptr && last_referenced_table != _table && !result_pos_list->empty()) {
+        // The last ReferenceSegment we added pointed to a table different from the table this segment is part of. Thus,
+        // we need to add the last result_chunk to the result_table and create a new chunk with a new ReferenceSegment.
 
+        for (auto column_idx = ColumnID(0); column_idx < last_referenced_table->column_count(); ++column_idx) {
+          const auto segment = std::make_shared<ReferenceSegment>(last_referenced_table, column_idx, result_pos_list);
+          result_chunk.add_segment(segment);
+        }
+        result_table->emplace_chunk(std::move(result_chunk));
+        result_chunk = Chunk();
+        result_pos_list = std::make_shared<PosList>();
+      }
+      last_referenced_table = _table;
+      _scan_segment(chunk_index, result_pos_list, dict_segment);
       continue;
     }
-    const auto& reference_segment = std::dynamic_pointer_cast<ReferenceSegment<T>>(segment);
+
+    const auto& reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment_to_scan);
     if (reference_segment != nullptr) {
+      if (last_referenced_table != nullptr && last_referenced_table != reference_segment->referenced_table() &&
+          !result_pos_list->empty()) {
+        // The last ReferenceSegment we added pointed to a table different from the table this ReferenceSegment points
+        // to. Thus, we need to add the last result_chunk to the result_table and create a new chunk with a new
+        // ReferenceSegment.
 
+        for (auto column_idx = ColumnID(0); column_idx < last_referenced_table->column_count(); ++column_idx) {
+          const auto segment = std::make_shared<ReferenceSegment>(last_referenced_table, column_idx, result_pos_list);
+          result_chunk.add_segment(segment);
+        }
+        result_table->emplace_chunk(std::move(result_chunk));
+        result_chunk = Chunk();
+        result_pos_list = std::make_shared<PosList>();
+      }
+      last_referenced_table = reference_segment->referenced_table();
+      _scan_segment(result_pos_list, reference_segment);
       continue;
     }
-    */
 
     Fail("Type mismatch: Cannot cast table segments to type of search_value.");
   }
 
-  Chunk result_chunk;
-  for (auto column_idx = ColumnID(0); column_idx < _table->column_count(); ++column_idx) {
-    const auto segment = std::make_shared<ReferenceSegment>(_table, column_idx, result_pos_list);
-    result_chunk.add_segment(segment);
+  if (!result_pos_list->empty()) {
+    for (auto column_idx = ColumnID(0); column_idx < last_referenced_table->column_count(); ++column_idx) {
+      const auto segment = std::make_shared<ReferenceSegment>(last_referenced_table, column_idx, result_pos_list);
+      result_chunk.add_segment(segment);
+    }
+    result_table->emplace_chunk(std::move(result_chunk));
+  } else {
+    auto& last_chunk = result_table->get_chunk(ChunkID(result_table->chunk_count() - 1));
+    if (last_chunk.column_count() == 0) {
+      Assert(result_table->chunk_count() == 1, "Only when the table has just one chunk it can be empty.");
+      for (auto column_idx = ColumnID(0); column_idx < result_table->column_count(); ++column_idx) {
+        last_chunk.add_segment(
+            make_shared_by_data_type<BaseSegment, ValueSegment>(result_table->column_type(column_idx)));
+      }
+    }
   }
-  result_table->emplace_chunk(std::move(result_chunk));
 
   return result_table;
 }
 
 template <typename T>
-const std::vector<ChunkOffset> TableScan::TableScanImpl<T>::_scan_segment(
-    std::shared_ptr<ValueSegment<T>> segment) const {
-  auto matchedRows = std::vector<ChunkOffset>();
+void TableScan::TableScanImpl<T>::_scan_segment(const ChunkID current_chunk_id, std::shared_ptr<PosList> pos_list,
+                                                const std::shared_ptr<ValueSegment<T>> segment) const {
   const auto& values = segment->values();
-  for (size_t i = 0; i < values.size(); ++i) {
+  for (auto i = ChunkOffset(0); i < values.size(); ++i) {
     if (_matches_search_value(values[i])) {
-      matchedRows.emplace_back(i);
+      auto row_id = RowID();
+      row_id.chunk_offset = i;
+      row_id.chunk_id = current_chunk_id;
+      pos_list->emplace_back(std::move(row_id));
     }
   }
-  return matchedRows;
+}
+
+template <typename T>
+void TableScan::TableScanImpl<T>::_scan_segment(const ChunkID current_chunk_id, std::shared_ptr<PosList> pos_list,
+                                                const std::shared_ptr<DictionarySegment<T>> segment) const {
+  for (size_t i = 0; i < segment->size(); ++i) {
+    if (_matches_search_value(segment->get(i))) {
+      auto row_id = RowID();
+      row_id.chunk_offset = i;
+      row_id.chunk_id = current_chunk_id;
+      pos_list->emplace_back(std::move(row_id));
+    }
+  }
+}
+
+template <typename T>
+void TableScan::TableScanImpl<T>::_scan_segment(std::shared_ptr<PosList> pos_list,
+                                                const std::shared_ptr<ReferenceSegment> segment) const {
+  const auto& ref_table = segment->referenced_table();
+  const auto& ref_pos_list = segment->pos_list();
+
+  for (const auto& pos : *ref_pos_list) {
+    const auto chunk_id = pos.chunk_id;
+    const auto chunk_offset = pos.chunk_offset;
+
+    const auto& referenced_chunk = ref_table->get_chunk(chunk_id);
+    const auto& referenced_segment = referenced_chunk.get_segment(segment->referenced_column_id());
+
+    bool match = false;
+
+    const auto& value_segment = std::dynamic_pointer_cast<ValueSegment<T>>(referenced_segment);
+    const auto& dict_segment = std::dynamic_pointer_cast<DictionarySegment<T>>(referenced_segment);
+    if (value_segment != nullptr) {
+      const auto& value = value_segment->values()[chunk_offset];
+      match = _matches_search_value(value);
+    } else if (dict_segment != nullptr) {
+      const auto& value = dict_segment->get(chunk_offset);
+      match = _matches_search_value(value);
+    } else {
+      Fail("ReferenceSegment did not point to either a ValueSegment or a DictionarySegment.");
+    }
+
+    if (match) {
+      auto row_id = RowID();
+      row_id.chunk_offset = chunk_offset;
+      row_id.chunk_id = chunk_id;
+      pos_list->emplace_back(row_id);
+    }
+  }
 }
 
 template <typename T>

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -22,8 +22,6 @@ class TableScan : public AbstractOperator {
   TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID column_id, const ScanType scan_type,
             const AllTypeVariant search_value);
 
-  ~TableScan();
-
   ColumnID column_id() const;
   ScanType scan_type() const;
   const AllTypeVariant& search_value() const;
@@ -37,8 +35,6 @@ class TableScan : public AbstractOperator {
 
   class BaseTableScanImpl {
    public:
-    BaseTableScanImpl() = default;
-
     virtual const std::shared_ptr<const Table> execute() const = 0;
   };
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -64,7 +64,7 @@ class TableScan : public AbstractOperator {
 
     bool _matches_search_value(const T& value) const;
 
-    std::pair<ValueID, ValueID> _get_value_ids(const std::shared_ptr<DictionarySegment<T>> segment) const;
+    bool _matches_value_id(const ValueID& valueID, const std::shared_ptr<DictionarySegment<T>> segment) const;
   };
 };
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -5,11 +5,11 @@
 #include <string>
 #include <vector>
 
-#include "../storage/dictionary_segment.hpp"
-#include "../storage/reference_segment.hpp"
-#include "../storage/value_segment.hpp"
 #include "abstract_operator.hpp"
 #include "all_type_variant.hpp"
+#include "storage/dictionary_segment.hpp"
+#include "storage/reference_segment.hpp"
+#include "storage/value_segment.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
 
@@ -39,7 +39,7 @@ class TableScan : public AbstractOperator {
    public:
     BaseTableScanImpl() = default;
 
-    virtual std::shared_ptr<const Table> execute() = 0;
+    virtual const std::shared_ptr<const Table> execute() const = 0;
   };
 
   template <typename T>
@@ -48,14 +48,16 @@ class TableScan : public AbstractOperator {
     TableScanImpl(const std::shared_ptr<const Table> table, ColumnID column_id, const ScanType scan_type,
                   const AllTypeVariant search_value);
 
-    // TODO: Mark return and method as const?
-    std::shared_ptr<const Table> execute() override;
+    const std::shared_ptr<const Table> execute() const override;
 
    protected:
     const std::shared_ptr<const Table> _table;
     const ColumnID _column_id;
     const ScanType _scan_type;
-    const AllTypeVariant _search_value;
+    const T _search_value;
+
+    void _add_chunk(const std::shared_ptr<Table>& result_table, std::shared_ptr<PosList>& result_pos_list,
+                    const std::shared_ptr<const Table>& referenced_table) const;
 
     void _scan_segment(const ChunkID current_chunk_id, std::shared_ptr<PosList> pos_list,
                        const std::shared_ptr<ValueSegment<T>> segment) const;

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -9,10 +9,10 @@
 #include "all_type_variant.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
+#include "../storage/value_segment.hpp"
 
 namespace opossum {
 
-class BaseTableScanImpl;
 class Table;
 
 class TableScan : public AbstractOperator {
@@ -28,6 +28,33 @@ class TableScan : public AbstractOperator {
 
  protected:
   std::shared_ptr<const Table> _on_execute() override;
+
+
+  class BaseTableScanImpl {
+  public:
+    BaseTableScanImpl() = default;
+  };
+
+  std::unique_ptr<BaseTableScanImpl> _table_scan_impl;
+
+  template <typename T>
+  class TableScanImpl : public BaseTableScanImpl {
+  public:
+    TableScanImpl(const std::shared_ptr<const Table> table, ColumnID column_id, const ScanType scan_type,
+                      const AllTypeVariant search_value);
+
+    std::shared_ptr<const Table> execute() const;
+
+  protected:
+    void _scan_segment(std::shared_ptr<Table> table, std::shared_ptr<ValueSegment<T>> segment) const;
+
+    bool _matches_search_value(const T& value) const;
+
+    const std::shared_ptr<const Table> _table;
+    const ColumnID _column_id;
+    const ScanType _scan_type;
+    const T _search_value;
+  };
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -64,7 +64,7 @@ class TableScan : public AbstractOperator {
 
     bool _matches_search_value(const T& value) const;
 
-    bool _matches_value_id(const ValueID& valueID, const std::shared_ptr<DictionarySegment<T>> segment) const;
+    bool _matches_value_id(const ValueID& valueID, const ValueID& lower_bound, const ValueID& upper_bound) const;
   };
 };
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "abstract_operator.hpp"
@@ -62,6 +63,8 @@ class TableScan : public AbstractOperator {
     void _scan_segment(std::shared_ptr<PosList> pos_list, const std::shared_ptr<ReferenceSegment> segment) const;
 
     bool _matches_search_value(const T& value) const;
+
+    std::pair<ValueID, ValueID> _get_value_ids(const std::shared_ptr<DictionarySegment<T>> segment) const;
   };
 };
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "../storage/dictionary_segment.hpp"
+#include "../storage/reference_segment.hpp"
 #include "../storage/value_segment.hpp"
 #include "abstract_operator.hpp"
 #include "all_type_variant.hpp"
@@ -38,8 +40,6 @@ class TableScan : public AbstractOperator {
     BaseTableScanImpl() = default;
 
     virtual std::shared_ptr<const Table> execute() = 0;
-
-   protected:
   };
 
   template <typename T>
@@ -57,7 +57,11 @@ class TableScan : public AbstractOperator {
     const ScanType _scan_type;
     const AllTypeVariant _search_value;
 
-    const std::vector<ChunkOffset> _scan_segment(std::shared_ptr<ValueSegment<T>> segment) const;
+    void _scan_segment(const ChunkID current_chunk_id, std::shared_ptr<PosList> pos_list,
+                       const std::shared_ptr<ValueSegment<T>> segment) const;
+    void _scan_segment(const ChunkID current_chunk_id, std::shared_ptr<PosList> pos_list,
+                       std::shared_ptr<DictionarySegment<T>> segment) const;
+    void _scan_segment(std::shared_ptr<PosList> pos_list, const std::shared_ptr<ReferenceSegment> segment) const;
 
     bool _matches_search_value(const T& value) const;
   };

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -27,25 +27,20 @@ class TableScan : public AbstractOperator {
   const AllTypeVariant& search_value() const;
 
  protected:
+  const ColumnID _column_id;
+  const ScanType _scan_type;
+  const AllTypeVariant _search_value;
+
   std::shared_ptr<const Table> _on_execute() override;
 
   class BaseTableScanImpl {
    public:
-    BaseTableScanImpl(const std::shared_ptr<const Table> table, ColumnID column_id, const ScanType scan_type,
-                      const AllTypeVariant search_value);
+    BaseTableScanImpl() = default;
 
     virtual std::shared_ptr<const Table> execute() = 0;
 
    protected:
-    const std::shared_ptr<const Table> _table;
-    const ColumnID _column_id;
-    const ScanType _scan_type;
-    const AllTypeVariant _search_value;
-
-    friend TableScan;
   };
-
-  std::unique_ptr<BaseTableScanImpl> _table_scan_impl;
 
   template <typename T>
   class TableScanImpl : public BaseTableScanImpl {
@@ -57,6 +52,11 @@ class TableScan : public AbstractOperator {
     std::shared_ptr<const Table> execute() override;
 
    protected:
+    const std::shared_ptr<const Table> _table;
+    const ColumnID _column_id;
+    const ScanType _scan_type;
+    const AllTypeVariant _search_value;
+
     const std::vector<ChunkOffset> _scan_segment(std::shared_ptr<ValueSegment<T>> segment) const;
 
     bool _matches_search_value(const T& value) const;

--- a/src/lib/storage/reference_segment.cpp
+++ b/src/lib/storage/reference_segment.cpp
@@ -1,0 +1,31 @@
+#include <memory>
+
+#include "reference_segment.hpp"
+#include "utils/performance_warning.hpp"
+
+namespace opossum {
+
+ReferenceSegment::ReferenceSegment(const std::shared_ptr<const opossum::Table> referenced_table,
+                                   const opossum::ColumnID referenced_column_id,
+                                   const std::shared_ptr<const opossum::PosList> pos)
+    : _referenced_table(referenced_table), _referenced_column_id(referenced_column_id), _pos_list(pos) {}
+
+const AllTypeVariant ReferenceSegment::operator[](const size_t i) const {
+  PerformanceWarning("operator[] used");
+
+  const auto& row_id = _pos_list->at(i);
+  const auto& chunk = _referenced_table->get_chunk(row_id.chunk_id);
+  const auto& segment = chunk.get_segment(_referenced_column_id);
+
+  return segment->operator[](row_id.chunk_offset);
+}
+
+size_t ReferenceSegment::size() const { return _pos_list->size(); }
+
+const std::shared_ptr<const PosList> ReferenceSegment::pos_list() const { return _pos_list; }
+
+const std::shared_ptr<const Table> ReferenceSegment::referenced_table() const { return _referenced_table; }
+
+ColumnID ReferenceSegment::referenced_column_id() const { return _referenced_column_id; }
+
+}  //  namespace opossum

--- a/src/lib/storage/reference_segment.hpp
+++ b/src/lib/storage/reference_segment.hpp
@@ -34,6 +34,11 @@ class ReferenceSegment : public BaseSegment {
   const std::shared_ptr<const Table> referenced_table() const;
 
   ColumnID referenced_column_id() const;
+
+ protected:
+  const std::shared_ptr<const Table> _referenced_table;
+  const ColumnID _referenced_column_id;
+  const std::shared_ptr<const PosList> _pos_list;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -21,7 +21,8 @@ namespace opossum {
 Table::Table(const uint32_t chunk_size) : _chunk_size{chunk_size} { _open_new_chunk(); }
 
 void Table::add_column_definition(const std::string& name, const std::string& type) {
-  // Implementation goes here
+  _column_names.push_back(name);
+  _column_types.push_back(type);
 }
 
 void Table::add_column(const std::string& name, const std::string& type) {
@@ -30,8 +31,7 @@ void Table::add_column(const std::string& name, const std::string& type) {
   DebugAssert(std::find(_column_names.begin(), _column_names.end(), name) == _column_names.end(),
               "column name already exists");
 
-  _column_names.push_back(name);
-  _column_types.push_back(type);
+  add_column_definition(name, type);
   _chunks.front().add_segment(make_shared_by_data_type<BaseSegment, ValueSegment>(type));
 }
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -18,7 +18,7 @@
 
 namespace opossum {
 
-Table::Table(const uint32_t chunk_size) : _chunk_size{chunk_size} { _open_new_chunk(); }
+Table::Table(const uint32_t chunk_size) : _chunk_size{chunk_size} { create_new_chunk(); }
 
 void Table::add_column_definition(const std::string& name, const std::string& type) {
   _column_names.push_back(name);
@@ -37,7 +37,7 @@ void Table::add_column(const std::string& name, const std::string& type) {
 
 void Table::append(std::vector<AllTypeVariant> values) {
   if (_is_latest_chunk_full()) {
-    _open_new_chunk();
+    create_new_chunk();
   }
 
   _chunks.back().append(values);
@@ -54,17 +54,13 @@ bool Table::_is_chunk_full(const ChunkID chunk_id) const {
   return chunk.size() >= chunk_size();
 }
 
-void Table::_open_new_chunk() {
+void Table::create_new_chunk() {
   Chunk chunk;
   for (const auto& column_type : _column_types) {
     chunk.add_segment(make_shared_by_data_type<BaseSegment, ValueSegment>(column_type));
   }
 
   _chunks.emplace_back(std::move(chunk));
-}
-
-void Table::create_new_chunk() {
-  // Implementation goes here
 }
 
 uint16_t Table::column_count() const {
@@ -132,10 +128,6 @@ void Table::compress_chunk(ChunkID chunk_id) {
 
   std::unique_lock<std::shared_mutex> lock(_chunks_mutex);
   _chunks.at(chunk_id) = std::move(compressed_chunk);
-}
-
-void emplace_chunk(Chunk chunk) {
-  // Implementation goes here
 }
 
 }  // namespace opossum

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -12,109 +12,109 @@
 
 namespace opossum {
 
-// class OperatorsPrintTest : public BaseTest {
-//  protected:
-//   void SetUp() override {
-//     t = std::make_shared<Table>(Table(chunk_size));
-//     t->add_column("col_1", "int");
-//     t->add_column("col_2", "string");
-//     StorageManager::get().add_table(table_name, t);
+class OperatorsPrintTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    t = std::make_shared<Table>(chunk_size);
+    t->add_column("col_1", "int");
+    t->add_column("col_2", "string");
+    StorageManager::get().add_table(table_name, t);
 
-//     gt = std::make_shared<GetTable>(table_name);
-//     gt->execute();
-//   }
+    gt = std::make_shared<GetTable>(table_name);
+    gt->execute();
+  }
 
-//   std::ostringstream output;
+  std::ostringstream output;
 
-//   std::string table_name = "printTestTable";
+  std::string table_name = "printTestTable";
 
-//   uint32_t chunk_size = 10;
+  uint32_t chunk_size = 10;
 
-//   std::shared_ptr<GetTable>(gt);
-//   std::shared_ptr<Table> t = nullptr;
-// };
+  std::shared_ptr<GetTable>(gt);
+  std::shared_ptr<Table> t = nullptr;
+};
 
-// // class used to make protected methods visible without
-// // modifying the base class with testing code.
-// class PrintWrapper : public Print {
-//   std::shared_ptr<const Table> tab;
+// class used to make protected methods visible without
+// modifying the base class with testing code.
+class PrintWrapper : public Print {
+  std::shared_ptr<const Table> tab;
 
-//  public:
-//   explicit PrintWrapper(const std::shared_ptr<AbstractOperator> in) : Print(in), tab(in->get_output()) {}
-//   std::vector<uint16_t> test_column_string_widths(uint16_t min, uint16_t max) {
-//     return column_string_widths(min, max, tab);
-//   }
-// };
+ public:
+  explicit PrintWrapper(const std::shared_ptr<AbstractOperator> in) : Print(in), tab(in->get_output()) {}
+  std::vector<uint16_t> test_column_string_widths(uint16_t min, uint16_t max) {
+    return column_string_widths(min, max, tab);
+  }
+};
 
-// TEST_F(OperatorsPrintTest, EmptyTable) {
-//   auto pr = std::make_shared<Print>(gt, output);
-//   pr->execute();
+TEST_F(OperatorsPrintTest, EmptyTable) {
+  auto pr = std::make_shared<Print>(gt, output);
+  pr->execute();
 
-//   // check if table is correctly passed
-//   EXPECT_EQ(pr->get_output(), t);
+  // check if table is correctly passed
+  EXPECT_EQ(pr->get_output(), t);
 
-//   auto output_str = output.str();
+  auto output_str = output.str();
 
-//   // rather hard-coded tests
-//   EXPECT_TRUE(output_str.find("col_1") != std::string::npos);
-//   EXPECT_TRUE(output_str.find("col_2") != std::string::npos);
-//   EXPECT_TRUE(output_str.find("int") != std::string::npos);
-//   EXPECT_TRUE(output_str.find("string") != std::string::npos);
+  // rather hard-coded tests
+  EXPECT_TRUE(output_str.find("col_1") != std::string::npos);
+  EXPECT_TRUE(output_str.find("col_2") != std::string::npos);
+  EXPECT_TRUE(output_str.find("int") != std::string::npos);
+  EXPECT_TRUE(output_str.find("string") != std::string::npos);
 
-//   EXPECT_TRUE(output_str.find("Empty chunk.") != std::string::npos);
-// }
+  EXPECT_TRUE(output_str.find("Empty chunk.") != std::string::npos);
+}
 
-// TEST_F(OperatorsPrintTest, FilledTable) {
-//   auto tab = StorageManager::get().get_table(table_name);
-//   for (size_t i = 0; i < chunk_size * 2; i++) {
-//     // char 97 is an 'a'
-//     tab->append({static_cast<int>(i % chunk_size), std::string(1, 97 + static_cast<int>(i / chunk_size))});
-//   }
+TEST_F(OperatorsPrintTest, FilledTable) {
+  auto tab = StorageManager::get().get_table(table_name);
+  for (size_t i = 0; i < chunk_size * 2; i++) {
+    // char 97 is an 'a'
+    tab->append({static_cast<int>(i % chunk_size), std::string(1, 97 + static_cast<int>(i / chunk_size))});
+  }
 
-//   auto pr = std::make_shared<Print>(gt, output);
-//   pr->execute();
+  auto pr = std::make_shared<Print>(gt, output);
+  pr->execute();
 
-//   // check if table is correctly passed
-//   EXPECT_EQ(pr->get_output(), tab);
+  // check if table is correctly passed
+  EXPECT_EQ(pr->get_output(), tab);
 
-//   auto output_str = output.str();
+  auto output_str = output.str();
 
-//   EXPECT_TRUE(output_str.find("Chunk 0") != std::string::npos);
-//   // there should not be a third chunk (at least that's the current impl)
-//   EXPECT_TRUE(output_str.find("Chunk 3") == std::string::npos);
+  EXPECT_TRUE(output_str.find("Chunk 0") != std::string::npos);
+  // there should not be a third chunk (at least that's the current impl)
+  EXPECT_TRUE(output_str.find("Chunk 3") == std::string::npos);
 
-//   // remove spaces
-//   output_str.erase(remove_if(output_str.begin(), output_str.end(), isspace), output_str.end());
+  // remove spaces
+  output_str.erase(remove_if(output_str.begin(), output_str.end(), isspace), output_str.end());
 
-//   EXPECT_TRUE(output_str.find("|2|a|") != std::string::npos);
-//   EXPECT_TRUE(output_str.find("|9|b|") != std::string::npos);
-//   EXPECT_TRUE(output_str.find("|10|a|") == std::string::npos);
+  EXPECT_TRUE(output_str.find("|2|a|") != std::string::npos);
+  EXPECT_TRUE(output_str.find("|9|b|") != std::string::npos);
+  EXPECT_TRUE(output_str.find("|10|a|") == std::string::npos);
 
-//   // EXPECT_TRUE(output_str.find("Empty chunk.") != std::string::npos);
-// }
+  // EXPECT_TRUE(output_str.find("Empty chunk.") != std::string::npos);
+}
 
-// TEST_F(OperatorsPrintTest, GetColumnWidths) {
-//   uint16_t min = 8;
-//   uint16_t max = 20;
+TEST_F(OperatorsPrintTest, GetColumnWidths) {
+  uint16_t min = 8;
+  uint16_t max = 20;
 
-//   auto tab = StorageManager::get().get_table(table_name);
+  auto tab = StorageManager::get().get_table(table_name);
 
-//   auto pr_wrap = std::make_shared<PrintWrapper>(gt);
-//   auto print_lengths = pr_wrap->test_column_string_widths(min, max);
+  auto pr_wrap = std::make_shared<PrintWrapper>(gt);
+  auto print_lengths = pr_wrap->test_column_string_widths(min, max);
 
-//   // we have two columns, thus two 'lengths'
-//   ASSERT_EQ(print_lengths.size(), static_cast<size_t>(2));
-//   // with empty columns and short col names, we should see the minimal lengths
-//   EXPECT_EQ(print_lengths.at(0), static_cast<size_t>(min));
-//   EXPECT_EQ(print_lengths.at(1), static_cast<size_t>(min));
+  // we have two columns, thus two 'lengths'
+  ASSERT_EQ(print_lengths.size(), static_cast<size_t>(2));
+  // with empty columns and short col names, we should see the minimal lengths
+  EXPECT_EQ(print_lengths.at(0), static_cast<size_t>(min));
+  EXPECT_EQ(print_lengths.at(1), static_cast<size_t>(min));
 
-//   int ten_digits_ints = 1234567890;
+  int ten_digits_ints = 1234567890;
 
-//   tab->append({ten_digits_ints, "quite a long string with more than $max chars"});
+  tab->append({ten_digits_ints, "quite a long string with more than $max chars"});
 
-//   print_lengths = pr_wrap->test_column_string_widths(min, max);
-//   EXPECT_EQ(print_lengths.at(0), static_cast<size_t>(10));
-//   EXPECT_EQ(print_lengths.at(1), static_cast<size_t>(max));
-// }
+  print_lengths = pr_wrap->test_column_string_widths(min, max);
+  EXPECT_EQ(print_lengths.at(0), static_cast<size_t>(10));
+  EXPECT_EQ(print_lengths.at(1), static_cast<size_t>(max));
+}
 
 }  // namespace opossum

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -20,251 +20,251 @@
 
 namespace opossum {
 
-// class OperatorsTableScanTest : public BaseTest {
-//  protected:
-//   void SetUp() override {
-//     _table_wrapper = std::make_shared<TableWrapper>(load_table("src/test/tables/int_float.tbl", 2));
-//     _table_wrapper->execute();
+class OperatorsTableScanTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    _table_wrapper = std::make_shared<TableWrapper>(load_table("src/test/tables/int_float.tbl", 2));
+    _table_wrapper->execute();
 
-//     std::shared_ptr<Table> test_even_dict = std::make_shared<Table>(5);
-//     test_even_dict->add_column("a", "int");
-//     test_even_dict->add_column("b", "int");
-//     for (int i = 0; i <= 24; i += 2) test_even_dict->append({i, 100 + i});
+    std::shared_ptr<Table> test_even_dict = std::make_shared<Table>(5);
+    test_even_dict->add_column("a", "int");
+    test_even_dict->add_column("b", "int");
+    for (int i = 0; i <= 24; i += 2) test_even_dict->append({i, 100 + i});
 
-//     test_even_dict->compress_chunk(ChunkID(0));
-//     test_even_dict->compress_chunk(ChunkID(1));
+    test_even_dict->compress_chunk(ChunkID(0));
+    test_even_dict->compress_chunk(ChunkID(1));
 
-//     _table_wrapper_even_dict = std::make_shared<TableWrapper>(std::move(test_even_dict));
-//     _table_wrapper_even_dict->execute();
-//   }
+    _table_wrapper_even_dict = std::make_shared<TableWrapper>(std::move(test_even_dict));
+    _table_wrapper_even_dict->execute();
+  }
 
-//   std::shared_ptr<TableWrapper> get_table_op_part_dict() {
-//     auto table = std::make_shared<Table>(5);
-//     table->add_column("a", "int");
-//     table->add_column("b", "float");
+  std::shared_ptr<TableWrapper> get_table_op_part_dict() {
+    auto table = std::make_shared<Table>(5);
+    table->add_column("a", "int");
+    table->add_column("b", "float");
 
-//     for (int i = 1; i < 20; ++i) {
-//       table->append({i, 100.1 + i});
-//     }
+    for (int i = 1; i < 20; ++i) {
+      table->append({i, 100.1 + i});
+    }
 
-//     table->compress_chunk(ChunkID(0));
-//     table->compress_chunk(ChunkID(1));
+    table->compress_chunk(ChunkID(0));
+    table->compress_chunk(ChunkID(1));
 
-//     auto table_wrapper = std::make_shared<TableWrapper>(table);
-//     table_wrapper->execute();
+    auto table_wrapper = std::make_shared<TableWrapper>(table);
+    table_wrapper->execute();
 
-//     return table_wrapper;
-//   }
+    return table_wrapper;
+  }
 
-//   std::shared_ptr<TableWrapper> get_table_op_with_n_dict_entries(const int num_entries) {
-//     // Set up dictionary encoded table with a dictionary consisting of num_entries entries.
-//     auto table = std::make_shared<opossum::Table>(0);
-//     table->add_column("a", "int");
-//     table->add_column("b", "float");
+  std::shared_ptr<TableWrapper> get_table_op_with_n_dict_entries(const int num_entries) {
+    // Set up dictionary encoded table with a dictionary consisting of num_entries entries.
+    auto table = std::make_shared<opossum::Table>(0);
+    table->add_column("a", "int");
+    table->add_column("b", "float");
 
-//     for (int i = 0; i <= num_entries; i++) {
-//       table->append({i, 100.0f + i});
-//     }
+    for (int i = 0; i <= num_entries; i++) {
+      table->append({i, 100.0f + i});
+    }
 
-//     table->compress_chunk(ChunkID(0));
+    table->compress_chunk(ChunkID(0));
 
-//     auto table_wrapper = std::make_shared<opossum::TableWrapper>(std::move(table));
-//     table_wrapper->execute();
-//     return table_wrapper;
-//   }
+    auto table_wrapper = std::make_shared<opossum::TableWrapper>(std::move(table));
+    table_wrapper->execute();
+    return table_wrapper;
+  }
 
-//   void ASSERT_COLUMN_EQ(std::shared_ptr<const Table> table, const ColumnID& column_id,
-//                         std::vector<AllTypeVariant> expected) {
-//     for (auto chunk_id = ChunkID{0u}; chunk_id < table->chunk_count(); ++chunk_id) {
-//       const auto& chunk = table->get_chunk(chunk_id);
+  void ASSERT_COLUMN_EQ(std::shared_ptr<const Table> table, const ColumnID& column_id,
+                        std::vector<AllTypeVariant> expected) {
+    for (auto chunk_id = ChunkID{0u}; chunk_id < table->chunk_count(); ++chunk_id) {
+      const auto& chunk = table->get_chunk(chunk_id);
 
-//       for (auto chunk_offset = ChunkOffset{0u}; chunk_offset < chunk.size(); ++chunk_offset) {
-//         const auto& segment = *chunk.get_segment(column_id);
+      for (auto chunk_offset = ChunkOffset{0u}; chunk_offset < chunk.size(); ++chunk_offset) {
+        const auto& segment = *chunk.get_segment(column_id);
 
-//         const auto found_value = segment[chunk_offset];
-//         const auto comparator = [found_value](const AllTypeVariant expected_value) {
-//           // returns equivalency, not equality to simulate std::multiset.
-//           // multiset cannot be used because it triggers a compiler / lib bug when built in CI
-//           return !(found_value < expected_value) && !(expected_value < found_value);
-//         };
+        const auto found_value = segment[chunk_offset];
+        const auto comparator = [found_value](const AllTypeVariant expected_value) {
+          // returns equivalency, not equality to simulate std::multiset.
+          // multiset cannot be used because it triggers a compiler / lib bug when built in CI
+          return !(found_value < expected_value) && !(expected_value < found_value);
+        };
 
-//         auto search = std::find_if(expected.begin(), expected.end(), comparator);
+        auto search = std::find_if(expected.begin(), expected.end(), comparator);
 
-//         ASSERT_TRUE(search != expected.end());
-//         expected.erase(search);
-//       }
-//     }
+        ASSERT_TRUE(search != expected.end());
+        expected.erase(search);
+      }
+    }
 
-//     ASSERT_EQ(expected.size(), 0u);
-//   }
+    ASSERT_EQ(expected.size(), 0u);
+  }
 
-//   std::shared_ptr<TableWrapper> _table_wrapper, _table_wrapper_even_dict;
-// };
+  std::shared_ptr<TableWrapper> _table_wrapper, _table_wrapper_even_dict;
+};
 
-// TEST_F(OperatorsTableScanTest, DoubleScan) {
-//   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered.tbl", 2);
+TEST_F(OperatorsTableScanTest, DoubleScan) {
+  std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered.tbl", 2);
 
-//   auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
-//   scan_1->execute();
+  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+  scan_1->execute();
 
-//   auto scan_2 = std::make_shared<TableScan>(scan_1, ColumnID{1}, ScanType::OpLessThan, 457.9);
-//   scan_2->execute();
+  auto scan_2 = std::make_shared<TableScan>(scan_1, ColumnID{1}, ScanType::OpLessThan, 457.9);
+  scan_2->execute();
 
-//   EXPECT_TABLE_EQ(scan_2->get_output(), expected_result);
-// }
+  EXPECT_TABLE_EQ(scan_2->get_output(), expected_result);
+}
 
-// TEST_F(OperatorsTableScanTest, EmptyResultScan) {
-//   auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, 90000);
-//   scan_1->execute();
+TEST_F(OperatorsTableScanTest, EmptyResultScan) {
+  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, 90000);
+  scan_1->execute();
 
-//   for (auto i = ChunkID{0}; i < scan_1->get_output()->chunk_count(); i++)
-//     EXPECT_EQ(scan_1->get_output()->get_chunk(i).column_count(), 2u);
-// }
+  for (auto i = ChunkID{0}; i < scan_1->get_output()->chunk_count(); i++)
+    EXPECT_EQ(scan_1->get_output()->get_chunk(i).column_count(), 2u);
+}
 
-// TEST_F(OperatorsTableScanTest, SingleScanReturnsCorrectRowCount) {
-//   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 1);
+TEST_F(OperatorsTableScanTest, SingleScanReturnsCorrectRowCount) {
+  std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 1);
 
-//   auto scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
-//   scan->execute();
+  auto scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+  scan->execute();
 
-//   EXPECT_TABLE_EQ(scan->get_output(), expected_result);
-// }
+  EXPECT_TABLE_EQ(scan->get_output(), expected_result);
+}
 
-// TEST_F(OperatorsTableScanTest, ScanOnDictColumn) {
-//   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
+TEST_F(OperatorsTableScanTest, ScanOnDictColumn) {
+  // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
-//   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-//   tests[ScanType::OpEquals] = {104};
-//   tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-//   tests[ScanType::OpLessThan] = {100, 102};
-//   tests[ScanType::OpLessThanEquals] = {100, 102, 104};
-//   tests[ScanType::OpGreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-//   tests[ScanType::OpGreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-//   for (const auto& test : tests) {
-//     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 4);
-//     scan->execute();
+  std::map<ScanType, std::vector<AllTypeVariant>> tests;
+  tests[ScanType::OpEquals] = {104};
+  tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::OpLessThan] = {100, 102};
+  tests[ScanType::OpLessThanEquals] = {100, 102, 104};
+  tests[ScanType::OpGreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::OpGreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  for (const auto& test : tests) {
+    auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 4);
+    scan->execute();
 
-//     ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
-//   }
-// }
+    ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
+  }
+}
 
-// TEST_F(OperatorsTableScanTest, ScanOnReferencedDictColumn) {
-//   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
+TEST_F(OperatorsTableScanTest, ScanOnReferencedDictColumn) {
+  // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
-//   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-//   tests[ScanType::OpEquals] = {104};
-//   tests[ScanType::OpNotEquals] = {100, 102, 106};
-//   tests[ScanType::OpLessThan] = {100, 102};
-//   tests[ScanType::OpLessThanEquals] = {100, 102, 104};
-//   tests[ScanType::OpGreaterThan] = {106};
-//   tests[ScanType::OpGreaterThanEquals] = {104, 106};
-//   for (const auto& test : tests) {
-//     auto scan1 = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{1}, ScanType::OpLessThan, 108);
-//     scan1->execute();
+  std::map<ScanType, std::vector<AllTypeVariant>> tests;
+  tests[ScanType::OpEquals] = {104};
+  tests[ScanType::OpNotEquals] = {100, 102, 106};
+  tests[ScanType::OpLessThan] = {100, 102};
+  tests[ScanType::OpLessThanEquals] = {100, 102, 104};
+  tests[ScanType::OpGreaterThan] = {106};
+  tests[ScanType::OpGreaterThanEquals] = {104, 106};
+  for (const auto& test : tests) {
+    auto scan1 = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{1}, ScanType::OpLessThan, 108);
+    scan1->execute();
 
-//     auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{0}, test.first, 4);
-//     scan2->execute();
+    auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{0}, test.first, 4);
+    scan2->execute();
 
-//     ASSERT_COLUMN_EQ(scan2->get_output(), ColumnID{1}, test.second);
-//   }
-// }
+    ASSERT_COLUMN_EQ(scan2->get_output(), ColumnID{1}, test.second);
+  }
+}
 
-// TEST_F(OperatorsTableScanTest, ScanPartiallyCompressed) {
-//   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered.tbl", 2);
+TEST_F(OperatorsTableScanTest, ScanPartiallyCompressed) {
+  std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered.tbl", 2);
 
-//   auto table_wrapper = get_table_op_part_dict();
-//   auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::OpLessThan, 10);
-//   scan_1->execute();
+  auto table_wrapper = get_table_op_part_dict();
+  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::OpLessThan, 10);
+  scan_1->execute();
 
-//   EXPECT_TABLE_EQ(scan_1->get_output(), expected_result);
-// }
+  EXPECT_TABLE_EQ(scan_1->get_output(), expected_result);
+}
 
-// TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValue) {
-//   const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-//   const auto no_rows = std::vector<AllTypeVariant>{};
+TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValue) {
+  const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  const auto no_rows = std::vector<AllTypeVariant>{};
 
-//   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-//   tests[ScanType::OpEquals] = no_rows;
-//   tests[ScanType::OpNotEquals] = all_rows;
-//   tests[ScanType::OpLessThan] = all_rows;
-//   tests[ScanType::OpLessThanEquals] = all_rows;
-//   tests[ScanType::OpGreaterThan] = no_rows;
-//   tests[ScanType::OpGreaterThanEquals] = no_rows;
+  std::map<ScanType, std::vector<AllTypeVariant>> tests;
+  tests[ScanType::OpEquals] = no_rows;
+  tests[ScanType::OpNotEquals] = all_rows;
+  tests[ScanType::OpLessThan] = all_rows;
+  tests[ScanType::OpLessThanEquals] = all_rows;
+  tests[ScanType::OpGreaterThan] = no_rows;
+  tests[ScanType::OpGreaterThanEquals] = no_rows;
 
-//   for (const auto& test : tests) {
-//     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 30);
-//     scan->execute();
+  for (const auto& test : tests) {
+    auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 30);
+    scan->execute();
 
-//     ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
-//   }
-// }
+    ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
+  }
+}
 
-// TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) {
-//   const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-//   const auto no_rows = std::vector<AllTypeVariant>{};
+TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) {
+  const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  const auto no_rows = std::vector<AllTypeVariant>{};
 
-//   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-//   tests[ScanType::OpEquals] = no_rows;
-//   tests[ScanType::OpNotEquals] = all_rows;
-//   tests[ScanType::OpLessThan] = no_rows;
-//   tests[ScanType::OpLessThanEquals] = no_rows;
-//   tests[ScanType::OpGreaterThan] = all_rows;
-//   tests[ScanType::OpGreaterThanEquals] = all_rows;
+  std::map<ScanType, std::vector<AllTypeVariant>> tests;
+  tests[ScanType::OpEquals] = no_rows;
+  tests[ScanType::OpNotEquals] = all_rows;
+  tests[ScanType::OpLessThan] = no_rows;
+  tests[ScanType::OpLessThanEquals] = no_rows;
+  tests[ScanType::OpGreaterThan] = all_rows;
+  tests[ScanType::OpGreaterThanEquals] = all_rows;
 
-//   for (const auto& test : tests) {
-//     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0} /* "a" */, test.first, -10);
-//     scan->execute();
+  for (const auto& test : tests) {
+    auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0} /* "a" */, test.first, -10);
+    scan->execute();
 
-//     ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
-//   }
-// }
+    ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
+  }
+}
 
-// TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
-//   // scanning for a value that is around the dictionary's bounds
+TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
+  // scanning for a value that is around the dictionary's bounds
 
-//   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-//   tests[ScanType::OpEquals] = {100};
-//   tests[ScanType::OpLessThan] = {};
-//   tests[ScanType::OpLessThanEquals] = {100};
-//   tests[ScanType::OpGreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-//   tests[ScanType::OpGreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-//   tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  std::map<ScanType, std::vector<AllTypeVariant>> tests;
+  tests[ScanType::OpEquals] = {100};
+  tests[ScanType::OpLessThan] = {};
+  tests[ScanType::OpLessThanEquals] = {100};
+  tests[ScanType::OpGreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::OpGreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
-//   for (const auto& test : tests) {
-//     auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 0);
-//     scan->execute();
+  for (const auto& test : tests) {
+    auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 0);
+    scan->execute();
 
-//     ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
-//   }
-// }
+    ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
+  }
+}
 
-// TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
-//   auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, 12345);
-//   scan_1->execute();
-//   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(0));
+TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
+  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, 12345);
+  scan_1->execute();
+  EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(0));
 
-//   // scan_1 produced an empty result
-//   auto scan_2 = std::make_shared<opossum::TableScan>(scan_1, ColumnID{1}, ScanType::OpEquals, 456.7);
-//   scan_2->execute();
+  // scan_1 produced an empty result
+  auto scan_2 = std::make_shared<opossum::TableScan>(scan_1, ColumnID{1}, ScanType::OpEquals, 456.7);
+  scan_2->execute();
 
-//   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(0));
-// }
+  EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(0));
+}
 
-// TEST_F(OperatorsTableScanTest, ScanOnWideDictionarySegment) {
-//   // 2**8 + 1 values require a data type of 16bit.
-//   const auto table_wrapper_dict_16 = get_table_op_with_n_dict_entries((1 << 8) + 1);
-//   auto scan_1 = std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, ScanType::OpGreaterThan, 200);
-//   scan_1->execute();
+TEST_F(OperatorsTableScanTest, ScanOnWideDictionarySegment) {
+  // 2**8 + 1 values require a data type of 16bit.
+  const auto table_wrapper_dict_16 = get_table_op_with_n_dict_entries((1 << 8) + 1);
+  auto scan_1 = std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, ScanType::OpGreaterThan, 200);
+  scan_1->execute();
 
-//   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(57));
+  EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(57));
 
-//   // 2**16 + 1 values require a data type of 32bit.
-//   const auto table_wrapper_dict_32 = get_table_op_with_n_dict_entries((1 << 16) + 1);
-//   auto scan_2 =
-//       std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, ScanType::OpGreaterThan, 65500);
-//   scan_2->execute();
+  // 2**16 + 1 values require a data type of 32bit.
+  const auto table_wrapper_dict_32 = get_table_op_with_n_dict_entries((1 << 16) + 1);
+  auto scan_2 =
+      std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, ScanType::OpGreaterThan, 65500);
+  scan_2->execute();
 
-//   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
-// }
+  EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
+}
 
 }  // namespace opossum

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -228,7 +228,7 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
   tests[ScanType::OpLessThanEquals] = {100};
   tests[ScanType::OpGreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   tests[ScanType::OpGreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-    tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 0);

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -135,8 +135,7 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumn) {
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
   tests[ScanType::OpEquals] = {104};
-  //TODO
-  //  tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   tests[ScanType::OpLessThan] = {100, 102};
   tests[ScanType::OpLessThanEquals] = {100, 102, 104};
   tests[ScanType::OpGreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
@@ -186,8 +185,7 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValu
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
   tests[ScanType::OpEquals] = no_rows;
-  //TODO
-  //  tests[ScanType::OpNotEquals] = all_rows;
+  tests[ScanType::OpNotEquals] = all_rows;
   tests[ScanType::OpLessThan] = all_rows;
   tests[ScanType::OpLessThanEquals] = all_rows;
   tests[ScanType::OpGreaterThan] = no_rows;
@@ -207,8 +205,7 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) 
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
   tests[ScanType::OpEquals] = no_rows;
-  //TODO
-  //  tests[ScanType::OpNotEquals] = all_rows;
+  tests[ScanType::OpNotEquals] = all_rows;
   tests[ScanType::OpLessThan] = no_rows;
   tests[ScanType::OpLessThanEquals] = no_rows;
   tests[ScanType::OpGreaterThan] = all_rows;
@@ -231,8 +228,7 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
   tests[ScanType::OpLessThanEquals] = {100};
   tests[ScanType::OpGreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   tests[ScanType::OpGreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  //TODO
-  //  tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+    tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 0);

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -135,7 +135,8 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumn) {
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
   tests[ScanType::OpEquals] = {104};
-  tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  //TODO
+  //  tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   tests[ScanType::OpLessThan] = {100, 102};
   tests[ScanType::OpLessThanEquals] = {100, 102, 104};
   tests[ScanType::OpGreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
@@ -185,7 +186,8 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValu
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
   tests[ScanType::OpEquals] = no_rows;
-  tests[ScanType::OpNotEquals] = all_rows;
+  //TODO
+  //  tests[ScanType::OpNotEquals] = all_rows;
   tests[ScanType::OpLessThan] = all_rows;
   tests[ScanType::OpLessThanEquals] = all_rows;
   tests[ScanType::OpGreaterThan] = no_rows;
@@ -205,7 +207,8 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) 
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
   tests[ScanType::OpEquals] = no_rows;
-  tests[ScanType::OpNotEquals] = all_rows;
+  //TODO
+  //  tests[ScanType::OpNotEquals] = all_rows;
   tests[ScanType::OpLessThan] = no_rows;
   tests[ScanType::OpLessThanEquals] = no_rows;
   tests[ScanType::OpGreaterThan] = all_rows;
@@ -228,7 +231,8 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
   tests[ScanType::OpLessThanEquals] = {100};
   tests[ScanType::OpGreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   tests[ScanType::OpGreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  //TODO
+  //  tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 0);

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -267,4 +267,15 @@ TEST_F(OperatorsTableScanTest, ScanOnWideDictionarySegment) {
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
 }
 
+TEST_F(OperatorsTableScanTest, Getters) {
+  const auto column_id = ColumnID{0};
+  const auto scan_type = ScanType::OpGreaterThanEquals;
+  const auto search_value = 1234;
+  auto scan = std::make_shared<TableScan>(_table_wrapper, column_id, scan_type, search_value);
+
+  EXPECT_EQ(scan->column_id(), column_id);
+  EXPECT_EQ(scan->scan_type(), scan_type);
+  EXPECT_EQ(type_cast<int>(scan->search_value()), search_value);
+}
+
 }  // namespace opossum

--- a/src/test/storage/reference_segment_test.cpp
+++ b/src/test/storage/reference_segment_test.cpp
@@ -19,77 +19,79 @@
 
 namespace opossum {
 
-// class ReferenceSegmentTest : public ::testing::Test {
-//   virtual void SetUp() {
-//     _test_table = std::make_shared<opossum::Table>(opossum::Table(3));
-//     _test_table->add_column("a", "int");
-//     _test_table->add_column("b", "float");
-//     _test_table->append({123, 456.7f});
-//     _test_table->append({1234, 457.7f});
-//     _test_table->append({12345, 458.7f});
-//     _test_table->append({54321, 458.7f});
-//     _test_table->append({12345, 458.7f});
+class ReferenceSegmentTest : public ::testing::Test {
+  virtual void SetUp() {
+    _test_table = std::make_shared<opossum::Table>(3);
+    _test_table->add_column("a", "int");
+    _test_table->add_column("b", "float");
+    _test_table->append({123, 456.7f});
+    _test_table->append({1234, 457.7f});
+    _test_table->append({12345, 458.7f});
+    _test_table->append({54321, 458.7f});
+    _test_table->append({12345, 458.7f});
 
-//     _test_table_dict = std::make_shared<opossum::Table>(5);
-//     _test_table_dict->add_column("a", "int");
-//     _test_table_dict->add_column("b", "int");
-//     for (int i = 0; i <= 24; i += 2) _test_table_dict->append({i, 100 + i});
+    _test_table_dict = std::make_shared<opossum::Table>(5);
+    _test_table_dict->add_column("a", "int");
+    _test_table_dict->add_column("b", "int");
+    for (int i = 0; i <= 24; i += 2) _test_table_dict->append({i, 100 + i});
 
-//     _test_table_dict->compress_chunk(ChunkID(0));
-//     _test_table_dict->compress_chunk(ChunkID(1));
+    _test_table_dict->compress_chunk(ChunkID(0));
+    _test_table_dict->compress_chunk(ChunkID(1));
 
-//     StorageManager::get().add_table("test_table_dict", _test_table_dict);
-//   }
+    StorageManager::get().add_table("test_table_dict", _test_table_dict);
+  }
 
-//  public:
-//   std::shared_ptr<opossum::Table> _test_table, _test_table_dict;
-// };
+  virtual void TearDown() { StorageManager::get().reset(); }
 
-// TEST_F(ReferenceSegmentTest, IsImmutable) {
-//   auto pos_list =
-//       std::make_shared<PosList>(std::initializer_list<RowID>({{ChunkID{0}, 0}, {ChunkID{0}, 1}, {ChunkID{0}, 2}}));
-//   auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
+ public:
+  std::shared_ptr<opossum::Table> _test_table, _test_table_dict;
+};
 
-//   EXPECT_THROW(reference_segment.append(1), std::logic_error);
-// }
+TEST_F(ReferenceSegmentTest, IsImmutable) {
+  auto pos_list =
+      std::make_shared<PosList>(std::initializer_list<RowID>({{ChunkID{0}, 0}, {ChunkID{0}, 1}, {ChunkID{0}, 2}}));
+  auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
 
-// TEST_F(ReferenceSegmentTest, RetrievesValues) {
-//   // PosList with (0, 0), (0, 1), (0, 2)
-//   auto pos_list = std::make_shared<PosList>(
-//       std::initializer_list<RowID>({RowID{ChunkID{0}, 0}, RowID{ChunkID{0}, 1}, RowID{ChunkID{0}, 2}}));
-//   auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
+  EXPECT_THROW(reference_segment.append(1), std::logic_error);
+}
 
-//   auto& column = *(_test_table->get_chunk(ChunkID{0}).get_segment(ColumnID{0}));
+TEST_F(ReferenceSegmentTest, RetrievesValues) {
+  // PosList with (0, 0), (0, 1), (0, 2)
+  auto pos_list = std::make_shared<PosList>(
+      std::initializer_list<RowID>({RowID{ChunkID{0}, 0}, RowID{ChunkID{0}, 1}, RowID{ChunkID{0}, 2}}));
+  auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
 
-//   EXPECT_EQ(reference_segment[0], column[0]);
-//   EXPECT_EQ(reference_segment[1], column[1]);
-//   EXPECT_EQ(reference_segment[2], column[2]);
-// }
+  auto& column = *(_test_table->get_chunk(ChunkID{0}).get_segment(ColumnID{0}));
 
-// TEST_F(ReferenceSegmentTest, RetrievesValuesOutOfOrder) {
-//   // PosList with (0, 1), (0, 2), (0, 0)
-//   auto pos_list = std::make_shared<PosList>(
-//       std::initializer_list<RowID>({RowID{ChunkID{0}, 1}, RowID{ChunkID{0}, 2}, RowID{ChunkID{0}, 0}}));
-//   auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
+  EXPECT_EQ(reference_segment[0], column[0]);
+  EXPECT_EQ(reference_segment[1], column[1]);
+  EXPECT_EQ(reference_segment[2], column[2]);
+}
 
-//   auto& column = *(_test_table->get_chunk(ChunkID{0}).get_segment(ColumnID{0}));
+TEST_F(ReferenceSegmentTest, RetrievesValuesOutOfOrder) {
+  // PosList with (0, 1), (0, 2), (0, 0)
+  auto pos_list = std::make_shared<PosList>(
+      std::initializer_list<RowID>({RowID{ChunkID{0}, 1}, RowID{ChunkID{0}, 2}, RowID{ChunkID{0}, 0}}));
+  auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
 
-//   EXPECT_EQ(reference_segment[0], column[1]);
-//   EXPECT_EQ(reference_segment[1], column[2]);
-//   EXPECT_EQ(reference_segment[2], column[0]);
-// }
+  auto& column = *(_test_table->get_chunk(ChunkID{0}).get_segment(ColumnID{0}));
 
-// TEST_F(ReferenceSegmentTest, RetrievesValuesFromChunks) {
-//   // PosList with (0, 2), (1, 0), (1, 1)
-//   auto pos_list = std::make_shared<PosList>(
-//       std::initializer_list<RowID>({RowID{ChunkID{0}, 2}, RowID{ChunkID{1}, 0}, RowID{ChunkID{1}, 1}}));
-//   auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
+  EXPECT_EQ(reference_segment[0], column[1]);
+  EXPECT_EQ(reference_segment[1], column[2]);
+  EXPECT_EQ(reference_segment[2], column[0]);
+}
 
-//   auto& column_1 = *(_test_table->get_chunk(ChunkID{0}).get_segment(ColumnID{0}));
-//   auto& column_2 = *(_test_table->get_chunk(ChunkID{1}).get_segment(ColumnID{0}));
+TEST_F(ReferenceSegmentTest, RetrievesValuesFromChunks) {
+  // PosList with (0, 2), (1, 0), (1, 1)
+  auto pos_list = std::make_shared<PosList>(
+      std::initializer_list<RowID>({RowID{ChunkID{0}, 2}, RowID{ChunkID{1}, 0}, RowID{ChunkID{1}, 1}}));
+  auto reference_segment = ReferenceSegment(_test_table, ColumnID{0}, pos_list);
 
-//   EXPECT_EQ(reference_segment[0], column_1[2]);
-//   EXPECT_EQ(reference_segment[2], column_2[1]);
-// }
+  auto& column_1 = *(_test_table->get_chunk(ChunkID{0}).get_segment(ColumnID{0}));
+  auto& column_2 = *(_test_table->get_chunk(ChunkID{1}).get_segment(ColumnID{0}));
+
+  EXPECT_EQ(reference_segment[0], column_1[2]);
+  EXPECT_EQ(reference_segment[2], column_2[1]);
+}
 
 }  // namespace opossum

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -9,6 +9,7 @@
 
 #include "../lib/resolve_type.hpp"
 #include "../lib/storage/table.hpp"
+#include "../lib/storage/value_segment.hpp"
 
 namespace opossum {
 
@@ -73,4 +74,24 @@ TEST_F(StorageTableTest, GetChunkSize) { EXPECT_EQ(t.chunk_size(), 2u); }
 
 TEST_F(StorageTableTest, ColumnNames) { EXPECT_EQ(t.column_names(), std::vector<std::string>({"col_1", "col_2"})); }
 
+TEST_F(StorageTableTest, EmplaceChunk) {
+  {
+    Chunk chunk;
+    chunk.add_segment(make_shared_by_data_type<BaseSegment, ValueSegment>(t.column_type(ColumnID(0))));
+    chunk.add_segment(make_shared_by_data_type<BaseSegment, ValueSegment>(t.column_type(ColumnID(1))));
+    t.emplace_chunk(std::move(chunk));
+    EXPECT_EQ(t.chunk_count(), 1u);
+  }
+
+  t.append({1, "Hallo"});
+  EXPECT_EQ(t.chunk_count(), 1u);
+
+  {
+    Chunk chunk;
+    chunk.add_segment(make_shared_by_data_type<BaseSegment, ValueSegment>(t.column_type(ColumnID(0))));
+    chunk.add_segment(make_shared_by_data_type<BaseSegment, ValueSegment>(t.column_type(ColumnID(1))));
+    t.emplace_chunk(std::move(chunk));
+    EXPECT_EQ(t.chunk_count(), 2u);
+  }
+}
 }  // namespace opossum


### PR DESCRIPTION
Here's some playground-code to try this:
```cpp
#include <iostream>
#include <memory>

#include "../lib/operators/get_table.hpp"
#include "../lib/operators/print.hpp"
#include "../lib/operators/table_scan.hpp"
#include "../lib/storage/storage_manager.hpp"
#include "../lib/storage/table.hpp"
#include "../lib/utils/assert.hpp"

using namespace opossum;

int main() {
  Assert(true, "We can use opossum files here :)");

  auto table = std::make_shared<Table>(3);

  table->add_column("A", "int");
  table->add_column("B", "int");
  table->add_column("C", "string");

  table->append({1, 2, "a"});
  table->append({2, 2, "b"});
  table->append({3, 3, "a"});
  table->append({4, 3, "b"});
  table->append({5, 2, "a"});
  table->append({6, 2, "b"});
  table->append({7, 3, "a"});
  table->append({8, 3, "b"});
  table->append({9, 2, "a"});
  table->append({10, 2, "b"});

  StorageManager::get().add_table("some_table", table);

  table->compress_chunk(ChunkID(0));
  table->compress_chunk(ChunkID(1));
  table->compress_chunk(ChunkID(2));

  {
    auto get_table = std::make_shared<GetTable>("some_table");
    auto print = std::make_shared<Print>(get_table);
    get_table->execute();
    print->execute();
  }

  {
    auto get_table = std::make_shared<GetTable>("some_table");
    auto scan1 = std::make_shared<TableScan>(get_table, ColumnID(1), ScanType::OpEquals, 2);
    auto scan2 = std::make_shared<TableScan>(scan1, ColumnID(2), ScanType::OpEquals, "a");
    auto print = std::make_shared<Print>(scan2);
    get_table->execute();
    scan1->execute();
    scan2->execute();
    print->execute();
  }

  return 0;
}
```